### PR TITLE
Suppress warnings + fix errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ This is a Homebrew Tap that installs the previous version of android-sdk which w
 ```
 brew install mrbfrank/android-sdk-24/android-sdk
 ```
+
+### Note
+- The Android Platform-Tools need to be installed as part of the SDK.

--- a/android-sdk.rb
+++ b/android-sdk.rb
@@ -19,9 +19,6 @@ class AndroidSdk < Formula
   depends_on :java
   depends_on :macos => :mountain_lion
 
-  conflicts_with "android-platform-tools",
-    :because => "The Android Platform-Tools need to be installed as part of the SDK."
-
   resource "completion" do
     url "https://android.googlesource.com/platform/sdk/+/7859e2e738542baf96c15e6c8b50bbdb410131b0/bash_completion/adb.bash?format=TEXT"
     mirror "https://raw.githubusercontent.com/Homebrew/formula-patches/c3b801f/android-sdk/adb.bash"
@@ -39,7 +36,7 @@ class AndroidSdk < Formula
     %w[android ddms draw9patch emulator
        emulator-arm emulator-x86 hierarchyviewer lint mksdcard
        monitor monkeyrunner traceview].each do |tool|
-      (bin/tool).write <<-EOS.undent
+      (bin/tool).write <<~EOS
         #!/bin/bash
         TOOL="#{prefix}/tools/#{tool}"
         exec "$TOOL" "$@"
@@ -47,7 +44,7 @@ class AndroidSdk < Formula
     end
 
     %w[zipalign].each do |tool|
-      (bin/tool).write <<-EOS.undent
+      (bin/tool).write <<~EOS
         #!/bin/bash
         TOOL="#{prefix}/build-tools/#{build_tools_version}/#{tool}"
         exec "$TOOL" "$@"
@@ -55,7 +52,7 @@ class AndroidSdk < Formula
     end
 
     %w[dmtracedump etc1tool hprof-conv].each do |tool|
-      (bin/tool).write <<-EOS.undent
+      (bin/tool).write <<~EOS
         #!/bin/bash
         TOOL="#{prefix}/platform-tools/#{tool}"
         exec "$TOOL" "$@"
@@ -71,7 +68,7 @@ class AndroidSdk < Formula
     end
 
     %w[adb fastboot].each do |platform_tool|
-      (bin/platform_tool).write <<-EOS.undent
+      (bin/platform_tool).write <<~EOS
         #!/bin/bash
         PLATFORM_TOOL="#{prefix}/platform-tools/#{platform_tool}"
         test -x "$PLATFORM_TOOL" && exec "$PLATFORM_TOOL" "$@"
@@ -82,7 +79,7 @@ class AndroidSdk < Formula
     end
 
     %w[aapt aidl dexdump dx llvm-rs-cc].each do |build_tool|
-      (bin/build_tool).write <<-EOS.undent
+      (bin/build_tool).write <<~EOS
         #!/bin/bash
         BUILD_TOOLS_VERSION='#{build_tools_version}'
         BUILD_TOOL="#{prefix}/build-tools/$BUILD_TOOLS_VERSION/#{build_tool}"
@@ -113,7 +110,7 @@ class AndroidSdk < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Now run the 'android' tool to install the actual SDK stuff.
 
     The Android-SDK is available at #{opt_prefix}


### PR DESCRIPTION
```Warning: android-sdk: No available formula with the name "android-platform-tools"
'conflicts_with "android-platform-tools"' should be removed from android-sdk.rb.
Please report this to the mrbfrank/android-sdk-24 tap!
```
```
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/mrbfrank/homebrew-android-sdk-24/android-sdk.rb:46:in `block in install'
Please report this to the mrbfrank/android-sdk-24 tap!
Or, even better, submit a PR to fix it!
```